### PR TITLE
Update Jupiter for Eclipse 09-23

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,18 +29,18 @@
 	<version>${revision}</version>
 
 	<properties>
-		<revision>1.3.0-SNAPSHOT</revision>
+		<revision>1.4.0-SNAPSHOT</revision>
 		<project.build.outputTimestamp>1980-02-01T00:00:00Z</project.build.outputTimestamp>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
 		<java.release>8</java.release>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<bnd.version>6.4.0</bnd.version>
+		<bnd.version>7.0.0</bnd.version>
 		<junit-jupiter.compile.version>5.6.0</junit-jupiter.compile.version>
 		<junit-platform.compile.version>1.6.0</junit-platform.compile.version>
-		<junit-jupiter.version>5.9.2</junit-jupiter.version>
-		<junit-platform.version>1.9.2</junit-platform.version>
+		<junit-jupiter.version>5.10.1</junit-jupiter.version>
+		<junit-platform.version>1.10.1</junit-platform.version>
 		<assertj.compile.version>3.24.2</assertj.compile.version>
 		<assertj.version>3.24.2</assertj.version>
 		<mockito.version>4.11.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 		<java.release>8</java.release>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<bnd.version>7.0.0</bnd.version>
+		<bnd.version>6.4.0</bnd.version>
 		<junit-jupiter.compile.version>5.6.0</junit-jupiter.compile.version>
 		<junit-platform.compile.version>1.6.0</junit-platform.compile.version>
 		<junit-jupiter.version>5.10.1</junit-jupiter.version>


### PR DESCRIPTION
- Updated Junit Jupiter to work with Eclipse 09-23 IDE
- use bnd 7.0.0 to build